### PR TITLE
feat(diagram-connection): add diagram connection UI store and integrate with database diagram

### DIFF
--- a/src/entities/solution/index.ts
+++ b/src/entities/solution/index.ts
@@ -27,3 +27,4 @@ export {
 	type SolutionStore,
 } from "./model/state/solutionStore";
 export { solutionSelector } from "./model/state/selectors";
+export { useDiagramConnectionUiStore } from "./model/state/diagram-connection-ui-store";

--- a/src/entities/solution/model/state/diagram-connection-ui-store.ts
+++ b/src/entities/solution/model/state/diagram-connection-ui-store.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { create } from "zustand";
+
+type DiagramConnectionUiState = {
+	isConnecting: boolean;
+	setIsConnecting: (isConnecting: boolean) => void;
+};
+
+export const useDiagramConnectionUiStore = create<DiagramConnectionUiState>()(
+	(set) => ({
+		isConnecting: false,
+		setIsConnecting: (isConnecting) => set({ isConnecting }),
+	}),
+);

--- a/src/features/modeling-solution/model/use-database-diagram.ts
+++ b/src/features/modeling-solution/model/use-database-diagram.ts
@@ -1,8 +1,9 @@
 import { useCallback, useMemo, useState } from "react";
-import type { Node, EdgeChange, NodeChange } from "@xyflow/react";
+import type { Connection, Node, EdgeChange, NodeChange } from "@xyflow/react";
 import type { TableData } from "@fsd/entities/solution";
 import { useShallow } from "zustand/shallow";
 import { useSolutionStore, solutionSelector } from "@fsd/entities/solution";
+import { useDiagramConnectionUiStore } from "@fsd/entities/solution";
 import { getNextAvailableSubmodelIndex } from "@fsd/entities/table/lib";
 import { generateRandomId } from "@fsd/shared/lib/ids";
 import { useTranslation } from "@fsd/shared/i18n/use-translation";
@@ -37,6 +38,9 @@ export const useDatabaseDiagram = () => {
 
 	const [isAddCollectionModalOpen, setIsAddCollectionModalOpen] =
 		useState(false);
+	const setIsConnecting = useDiagramConnectionUiStore(
+		(state) => state.setIsConnecting,
+	);
 
 	const connectionConfig = useMemo(
 		() => ({
@@ -115,13 +119,31 @@ export const useDatabaseDiagram = () => {
 		[onNodesChange, handleNodeRemove, nodes],
 	);
 
+	const handleConnectStart = useCallback(() => {
+		setIsConnecting(true);
+	}, [setIsConnecting]);
+
+	const handleConnectEnd = useCallback(() => {
+		setIsConnecting(false);
+	}, [setIsConnecting]);
+
+	const handleConnectWithState = useCallback(
+		(connection: Connection) => {
+			handleConnect(connection);
+			setIsConnecting(false);
+		},
+		[handleConnect, setIsConnecting],
+	);
+
 	const reactFlowProps = useMemo(
 		() => ({
 			nodes,
 			edges,
 			onEdgesChange: handleEdgesChange,
 			onNodesChange: handleNodesChange,
-			onConnect: handleConnect,
+			onConnect: handleConnectWithState,
+			onConnectStart: handleConnectStart,
+			onConnectEnd: handleConnectEnd,
 			connectionLineStyle,
 			defaultEdgeOptions: {
 				type: "floating" as const,
@@ -135,7 +157,15 @@ export const useDatabaseDiagram = () => {
 			},
 			fitView: true,
 		}),
-		[nodes, edges, handleEdgesChange, handleNodesChange, handleConnect],
+		[
+			nodes,
+			edges,
+			handleEdgesChange,
+			handleNodesChange,
+			handleConnectWithState,
+			handleConnectStart,
+			handleConnectEnd,
+		],
 	);
 
 	return {

--- a/src/widgets/diagram-canvas/ui/TableNode.tsx
+++ b/src/widgets/diagram-canvas/ui/TableNode.tsx
@@ -1,14 +1,28 @@
 "use client";
 
+import { useState } from "react";
 import { Handle, Position } from "@xyflow/react";
 import type { NodeTypes } from "@xyflow/react";
 
-import type { TableNodeProps } from "@fsd/entities/solution";
+import {
+	type TableNodeProps,
+	useDiagramConnectionUiStore,
+} from "@fsd/entities/solution";
 import { TableNodeContainer } from "./TableNodeContainer";
 
 export const TableNode = ({ data, id }: TableNodeProps) => {
+	const [isHovered, setIsHovered] = useState(false);
+	const isConnecting = useDiagramConnectionUiStore(
+		(state) => state.isConnecting,
+	);
+	const isTargetActive = isConnecting && isHovered;
+
 	return (
-		<div className="relative w-full h-full ">
+		<div
+			className="relative w-full h-full "
+			onMouseEnter={() => setIsHovered(true)}
+			onMouseLeave={() => setIsHovered(false)}
+		>
 			<Handle
 				type="target"
 				position={Position.Bottom}
@@ -22,6 +36,9 @@ export const TableNode = ({ data, id }: TableNodeProps) => {
 					transform: "translate(-77%, 0%)",
 					cursor: "crosshair",
 					zIndex: 10,
+					opacity: isTargetActive ? 1 : 0,
+					pointerEvents: isTargetActive ? "auto" : "none",
+					transition: "opacity 0.12s ease",
 				}}
 			/>
 


### PR DESCRIPTION


- Introduced `useDiagramConnectionUiStore` for managing connection state in the diagram.
- Updated `useDatabaseDiagram` to handle connection start and end events.
- Enhanced `TableNode` component to reflect connection state visually during user interactions.